### PR TITLE
[fix] - broken block height query

### DIFF
--- a/wordle/init.sh
+++ b/wordle/init.sh
@@ -9,7 +9,7 @@ STAKING_AMOUNT="1000000000stake"
 
 NAMESPACE_ID=$(echo $RANDOM | md5sum | head -c 16; echo;)
 echo $NAMESPACE_ID
-DA_BLOCK_HEIGHT=$(curl https://rpc.limani.celestia-devops.dev/block?height | jq -r '.result.block.header.height')
+DA_BLOCK_HEIGHT=$(curl https://rpc.limani.celestia-devops.dev/block | jq -r '.result.block.header.height')
 echo $DA_BLOCK_HEIGHT
 
 rm -rf "$HOME"/.wordled


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This fixes a broken block height query in the `init.sh` script. 

```sh
manav@Manavs-MBP wordle % curl https://rpc.limani.celestia-devops.dev/block?height
zsh: no matches found: https://rpc.limani.celestia-devops.dev/block?height
```

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
